### PR TITLE
Add a simple IPC Provider

### DIFF
--- a/Proteus/Interop/IpcProvider.cs
+++ b/Proteus/Interop/IpcProvider.cs
@@ -1,0 +1,95 @@
+﻿global using IpcOverlayDetail = (string ModDirectory, string Name, int Priority);
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Services;
+using Proteus.Services;
+
+namespace Proteus.Interop;
+
+public class IpcProvider : IDisposable {
+    private const string IpcNamespace = nameof(Proteus);
+    private const int MajorVersion = 1;
+    private const int MinorVersion = 0;
+
+    private readonly IPluginLog _log;
+    private readonly CompositorService _compositor;
+    private readonly SidecarDiscoveryService _discovery;
+
+    private readonly ICallGateProvider<List<IpcOverlayDetail>> _getOverlaysProvider;
+    private readonly ICallGateProvider<(int, int)> _apiVersionProvider;
+    private readonly ICallGateProvider<object> _recompositeProvider;
+    private readonly ICallGateProvider<string, string> _getColorTableProvider;
+    private readonly ICallGateProvider<string, string, bool> _setColorTableProvider;
+    
+    public IpcProvider(IDalamudPluginInterface pluginInterface, CompositorService compositor, SidecarDiscoveryService discovery, IPluginLog log) {
+        _compositor = compositor;
+        _discovery = discovery;
+        _log = log;
+        
+        _apiVersionProvider = pluginInterface.GetIpcProvider<(int, int)>($"{IpcNamespace}.ApiVersion");
+        _apiVersionProvider.RegisterFunc(() => (MajorVersion, MinorVersion));
+        
+        _getOverlaysProvider = pluginInterface.GetIpcProvider<List<IpcOverlayDetail>>($"{IpcNamespace}.{nameof(GetOverlays)}");
+        _getOverlaysProvider.RegisterFunc(GetOverlays);
+        
+        _recompositeProvider = pluginInterface.GetIpcProvider<object>($"{IpcNamespace}.{nameof(Recomposite)}");
+        _recompositeProvider.RegisterAction(Recomposite);
+        
+        _getColorTableProvider = pluginInterface.GetIpcProvider<string, string>($"{IpcNamespace}.{nameof(GetColorTable)}");
+        _getColorTableProvider.RegisterFunc(GetColorTable);
+        
+        _setColorTableProvider = pluginInterface.GetIpcProvider<string, string, bool>($"{IpcNamespace}.{nameof(SetColorTable)}");
+        _setColorTableProvider.RegisterFunc(SetColorTable);
+    }
+    
+    private List<IpcOverlayDetail> GetOverlays() {
+        return _compositor.LastDiscovered.Select(overlay => (overlay.ModDirectory, overlay.ModName, overlay.Priority)).ToList();
+    }
+
+    public void Dispose() {
+        _apiVersionProvider.UnregisterFunc();
+        _getOverlaysProvider.UnregisterFunc();
+        _recompositeProvider.UnregisterAction();
+        _getColorTableProvider.UnregisterFunc();
+        _setColorTableProvider.UnregisterFunc();
+    }
+    
+    private void Recomposite() {
+        _compositor.TriggerRecomposite("ipc-requested");
+    }
+    
+    private string GetColorTable(string modDirectory) {
+        try {
+            var entry = _compositor.LastDiscovered.FirstOrDefault(s => s.ModDirectory == modDirectory);
+            if (entry == null) return string.Empty;
+            var colorTable = _discovery.GetMergedColorRows(entry);
+            return JsonSerializer.Serialize(colorTable);
+        } catch (Exception ex) {
+            _log.Error(ex, "Error in IPC GetColorTable");
+            return string.Empty;
+        }
+    }
+    
+    private bool SetColorTable(string modDirectory, string colorTableJson) {
+        try {
+            var entry = _compositor.LastDiscovered.FirstOrDefault(s => s.ModDirectory == modDirectory);
+            if (entry == null) return false;
+            var newColorTable = JsonSerializer.Deserialize<List<ColorTableRowPreset>>(colorTableJson);
+            if (newColorTable == null) return false;
+            var colorTable = _discovery.GetEditableColorRows(entry);
+            colorTable.Clear();
+            colorTable.AddRange(newColorTable);
+            _discovery.SaveMetadata(entry);
+            _compositor.TriggerRecomposite("ipc-colors-change");
+            return true;
+        } catch (Exception ex) {
+            _log.Error(ex, "Error in IPC SetColorTable");
+            return false;
+        }
+    }
+}

--- a/Proteus/Interop/IpcProvider.cs
+++ b/Proteus/Interop/IpcProvider.cs
@@ -1,4 +1,9 @@
-﻿global using IpcOverlayDetail = (string ModDirectory, string Name, int Priority);
+﻿global using IpcOverlayDetail = (
+    string ModDirectory, 
+    string Name, 
+    int Priority, 
+    System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>>? Options
+);
 
 using System;
 using System.Collections.Generic;
@@ -21,10 +26,11 @@ public class IpcProvider : IDisposable {
     private readonly SidecarDiscoveryService _discovery;
 
     private readonly ICallGateProvider<List<IpcOverlayDetail>> _getOverlaysProvider;
+    private readonly ICallGateProvider<List<IpcOverlayDetail>> _getActiveOverlaysProvider;
     private readonly ICallGateProvider<(int, int)> _apiVersionProvider;
     private readonly ICallGateProvider<object> _recompositeProvider;
-    private readonly ICallGateProvider<string, string> _getColorTableProvider;
-    private readonly ICallGateProvider<string, string, bool> _setColorTableProvider;
+    private readonly ICallGateProvider<string, string?, string?, string> _getColorTableProvider;
+    private readonly ICallGateProvider<string, string?, string?, string, bool> _setColorTableProvider;
     
     public IpcProvider(IDalamudPluginInterface pluginInterface, CompositorService compositor, SidecarDiscoveryService discovery, IPluginLog log) {
         _compositor = compositor;
@@ -37,53 +43,84 @@ public class IpcProvider : IDisposable {
         _getOverlaysProvider = pluginInterface.GetIpcProvider<List<IpcOverlayDetail>>($"{IpcNamespace}.{nameof(GetOverlays)}");
         _getOverlaysProvider.RegisterFunc(GetOverlays);
         
+        _getActiveOverlaysProvider = pluginInterface.GetIpcProvider<List<IpcOverlayDetail>>($"{IpcNamespace}.{nameof(GetActiveOverlays)}");
+        _getActiveOverlaysProvider.RegisterFunc(GetActiveOverlays);
+        
         _recompositeProvider = pluginInterface.GetIpcProvider<object>($"{IpcNamespace}.{nameof(Recomposite)}");
         _recompositeProvider.RegisterAction(Recomposite);
         
-        _getColorTableProvider = pluginInterface.GetIpcProvider<string, string>($"{IpcNamespace}.{nameof(GetColorTable)}");
+        _getColorTableProvider = pluginInterface.GetIpcProvider<string, string?, string?, string>($"{IpcNamespace}.{nameof(GetColorTable)}");
         _getColorTableProvider.RegisterFunc(GetColorTable);
         
-        _setColorTableProvider = pluginInterface.GetIpcProvider<string, string, bool>($"{IpcNamespace}.{nameof(SetColorTable)}");
+        _setColorTableProvider = pluginInterface.GetIpcProvider<string, string?, string?, string, bool>($"{IpcNamespace}.{nameof(SetColorTable)}");
         _setColorTableProvider.RegisterFunc(SetColorTable);
     }
     
     private List<IpcOverlayDetail> GetOverlays() {
-        return _compositor.LastDiscovered.Select(overlay => (overlay.ModDirectory, overlay.ModName, overlay.Priority)).ToList();
+        return _compositor.LastDiscovered.Select(overlay => (
+            overlay.ModDirectory, 
+            overlay.ModName,
+            overlay.Priority,
+            overlay.Metadata.OptionGroups?.ToDictionary(g => g.PenumbraGroupName, g => g.Options.Select(o => o.Name).ToList())
+          )).ToList();
     }
-
-    public void Dispose() {
-        _apiVersionProvider.UnregisterFunc();
-        _getOverlaysProvider.UnregisterFunc();
-        _recompositeProvider.UnregisterAction();
-        _getColorTableProvider.UnregisterFunc();
-        _setColorTableProvider.UnregisterFunc();
+    
+    private List<IpcOverlayDetail> GetActiveOverlays() {
+        return _compositor.LastDiscovered.Select(overlay => (
+            overlay.ModDirectory, 
+            overlay.ModName,
+            overlay.Priority,
+            overlay.Metadata.OptionGroups == null ? null : _discovery.ResolveActiveOverlays(overlay)
+                                                                     .GroupBy(g => g.OptionGroup)
+                                                                     .ToDictionary(
+                                                                         grouping => grouping.Key ?? string.Empty, 
+                                                                         grouping => grouping.Select( o => o.Option).ToList()
+                                                                         )
+          )).ToList();
     }
     
     private void Recomposite() {
         _compositor.TriggerRecomposite("ipc-requested");
     }
     
-    private string GetColorTable(string modDirectory) {
+    private string GetColorTable(string modDirectory, string? group, string? option) {
         try {
             var entry = _compositor.LastDiscovered.FirstOrDefault(s => s.ModDirectory.Equals(modDirectory, StringComparison.InvariantCultureIgnoreCase));
             if (entry == null) return string.Empty;
-            var colorTable = _discovery.GetMergedColorRows(entry);
-            return JsonSerializer.Serialize(colorTable);
+
+            if (group != null) {
+                if (option == null || entry.Metadata.OptionGroups == null) return string.Empty;
+                var overlayOptionGroup = entry.Metadata.OptionGroups?.FirstOrDefault(g => g.PenumbraGroupName.Equals(group, StringComparison.InvariantCultureIgnoreCase));
+                var overlayOption = overlayOptionGroup?.Options.FirstOrDefault(o => o.Name.Equals(option, StringComparison.InvariantCultureIgnoreCase));
+                if (overlayOption?.ColorTableRows == null) return string.Empty;
+                return JsonSerializer.Serialize(overlayOption.ColorTableRows);
+            }
+            
+            if (entry.Metadata.ColorTableRows == null) return string.Empty;
+            return JsonSerializer.Serialize(entry.Metadata.ColorTableRows);
         } catch (Exception ex) {
             _log.Error(ex, "Error in IPC GetColorTable");
             return string.Empty;
         }
     }
     
-    private bool SetColorTable(string modDirectory, string colorTableJson) {
+    private bool SetColorTable(string modDirectory, string? group, string? option, string colorTableJson) {
         try {
             var entry = _compositor.LastDiscovered.FirstOrDefault(s => s.ModDirectory.Equals(modDirectory, StringComparison.InvariantCultureIgnoreCase));
             if (entry == null) return false;
-            var newColorTable = JsonSerializer.Deserialize<List<ColorTableRowPreset>>(colorTableJson);
-            if (newColorTable == null) return false;
-            var colorTable = _discovery.GetEditableColorRows(entry);
-            colorTable.Clear();
-            colorTable.AddRange(newColorTable);
+            var newColorTable = string.IsNullOrWhiteSpace(colorTableJson) ? null : JsonSerializer.Deserialize<List<ColorTableRowPreset>>(colorTableJson);
+
+            if (group != null) {
+                if (option == null) return false;
+                if (entry.Metadata.OptionGroups == null) return false;
+                var overlayOptionGroup = entry.Metadata.OptionGroups?.FirstOrDefault(g => g.PenumbraGroupName.Equals(group, StringComparison.InvariantCultureIgnoreCase));
+                var overlayOption = overlayOptionGroup?.Options.FirstOrDefault(o => o.Name.Equals(option, StringComparison.InvariantCultureIgnoreCase));
+                if (overlayOption == null) return false;
+                overlayOption.ColorTableRows =  newColorTable;
+            } else {
+                entry.Metadata.ColorTableRows = newColorTable;
+            }
+
             _discovery.SaveMetadata(entry);
             _compositor.TriggerRecomposite("ipc-colors-change");
             return true;
@@ -91,5 +128,14 @@ public class IpcProvider : IDisposable {
             _log.Error(ex, "Error in IPC SetColorTable");
             return false;
         }
+    }
+    
+    public void Dispose() {
+        _apiVersionProvider.UnregisterFunc();
+        _getOverlaysProvider.UnregisterFunc();
+        _getActiveOverlaysProvider.UnregisterFunc();
+        _recompositeProvider.UnregisterAction();
+        _getColorTableProvider.UnregisterFunc();
+        _setColorTableProvider.UnregisterFunc();
     }
 }

--- a/Proteus/Interop/IpcProvider.cs
+++ b/Proteus/Interop/IpcProvider.cs
@@ -65,7 +65,7 @@ public class IpcProvider : IDisposable {
     
     private string GetColorTable(string modDirectory) {
         try {
-            var entry = _compositor.LastDiscovered.FirstOrDefault(s => s.ModDirectory == modDirectory);
+            var entry = _compositor.LastDiscovered.FirstOrDefault(s => s.ModDirectory.Equals(modDirectory, StringComparison.InvariantCultureIgnoreCase));
             if (entry == null) return string.Empty;
             var colorTable = _discovery.GetMergedColorRows(entry);
             return JsonSerializer.Serialize(colorTable);
@@ -77,7 +77,7 @@ public class IpcProvider : IDisposable {
     
     private bool SetColorTable(string modDirectory, string colorTableJson) {
         try {
-            var entry = _compositor.LastDiscovered.FirstOrDefault(s => s.ModDirectory == modDirectory);
+            var entry = _compositor.LastDiscovered.FirstOrDefault(s => s.ModDirectory.Equals(modDirectory, StringComparison.InvariantCultureIgnoreCase));
             if (entry == null) return false;
             var newColorTable = JsonSerializer.Deserialize<List<ColorTableRowPreset>>(colorTableJson);
             if (newColorTable == null) return false;

--- a/Proteus/Plugin.cs
+++ b/Proteus/Plugin.cs
@@ -28,6 +28,7 @@ public sealed class Plugin : IDalamudPlugin
     private readonly CompositorService compositor;
     private readonly WindowSystem windowSystem;
     private readonly StatusWindow statusWindow;
+    private readonly IpcProvider ipcProvider;
 
     public Plugin(
         IDalamudPluginInterface pluginInterface,
@@ -43,6 +44,7 @@ public sealed class Plugin : IDalamudPlugin
         textureLoader = new TextureLoader(DataManager, log);
         discovery = new SidecarDiscoveryService(penumbra, log);
         compositor = new CompositorService(penumbra, glamourer, discovery, textureLoader, config, log);
+        ipcProvider = new IpcProvider(pluginInterface, compositor, discovery, log);
 
         statusWindow = new StatusWindow(compositor, discovery, penumbra, config);
 
@@ -82,6 +84,7 @@ public sealed class Plugin : IDalamudPlugin
         PluginInterface.UiBuilder.OpenMainUi -= OpenMainUi;
 
         windowSystem.RemoveAllWindows();
+        ipcProvider.Dispose();
         compositor.Dispose();
         glamourer.Dispose();
         penumbra.Dispose();

--- a/Proteus/Services/SidecarDiscoveryService.cs
+++ b/Proteus/Services/SidecarDiscoveryService.cs
@@ -23,7 +23,9 @@ public record OverlayEntry(
 /// </summary>
 public record ResolvedOverlay(
     OverlayDescriptor Descriptor,
-    List<ColorTableRowPreset>? ColorTableRows
+    List<ColorTableRowPreset>? ColorTableRows,
+    string? OptionGroup,
+    string? Option
 );
 
 public class SidecarDiscoveryService
@@ -95,7 +97,7 @@ public class SidecarDiscoveryService
     {
         if (entry.Metadata.Overlays is { Count: > 0 })
             return entry.Metadata.Overlays
-                .Select(d => new ResolvedOverlay(d, entry.Metadata.ColorTableRows))
+                .Select(d => new ResolvedOverlay(d, entry.Metadata.ColorTableRows, null, null))
                 .ToList();
 
         if (entry.Metadata.OptionGroups == null) return [];
@@ -125,7 +127,7 @@ public class SidecarDiscoveryService
             {
                 var rows = opt.ColorTableRows ?? entry.Metadata.ColorTableRows;
                 foreach (var desc in opt.Overlays)
-                    resolved.Add(new ResolvedOverlay(desc, rows));
+                    resolved.Add(new ResolvedOverlay(desc, rows, group.PenumbraGroupName, opt.Name));
             }
         }
         return resolved;


### PR DESCRIPTION
Adds an Ipc provider to allow other plugins to
- Query active overlay list (`Proteus.GetOverlays`)
- Get active color tables (`Proteus.GetColorTable`)
- Override color tables (`Proteus.SetColorTable`)
- Request recomposition (`Proteus.Recomposite`)

