### PR TITLE
Fix: glamourer equip attempts failing causes full redraw every frame

### DIFF
--- a/Proteus/Interop/GlamourerBridge.cs
+++ b/Proteus/Interop/GlamourerBridge.cs
@@ -233,7 +233,12 @@ public class GlamourerBridge : IDisposable
             var ec = reapplyState.Invoke(0, 0, ApplyFlag.Equipment);
             if (ec != GlamourerApiEc.Success)
             {
-                log.Debug("[Proteus] ReapplyState -> {0} (falling back to redraw)", ec);
+                // InvalidKey means another plugin holds a lock on this state, so the cheap in-place
+                // reload is unavailable and every composite falls back to a full redraw instead.
+                if (ec == GlamourerApiEc.InvalidKey)
+                    log.Warning("[Proteus] ReapplyState refused: another plugin holds a Glamourer lock on this character. Falling back to a full redraw.");
+                else
+                    log.Debug("[Proteus] ReapplyState -> {0} (falling back to redraw)", ec);
                 return false;
             }
             return true;
@@ -260,7 +265,10 @@ public class GlamourerBridge : IDisposable
             var ec = setBonusItem.Invoke(0, ApiBonusSlot.Glasses, itemId, key: 0, ApplyFlag.Once);
             if (ec != GlamourerApiEc.Success)
             {
-                log.Debug("[Proteus] SetBonusItem(Glasses,{0}) -> {1}", itemId, ec);
+                if (ec == GlamourerApiEc.InvalidKey)
+                    log.Warning("[Proteus] SetBonusItem(Glasses,{0}) refused: another plugin holds a Glamourer lock on the Glasses slot.", itemId);
+                else
+                    log.Debug("[Proteus] SetBonusItem(Glasses,{0}) -> {1}", itemId, ec);
                 return false;
             }
             return true;
@@ -330,7 +338,10 @@ public class GlamourerBridge : IDisposable
             var ec = setItem.Invoke(0, slot, itemId, NoStains, key: 0, ApplyFlag.Once);
             if (ec != GlamourerApiEc.Success)
             {
-                log.Debug("[Proteus] SetItem({0},{1}) -> {2}", slot, itemId, ec);
+                if (ec == GlamourerApiEc.InvalidKey)
+                    log.Warning("[Proteus] SetItem({0},{1}) refused: another plugin holds a Glamourer lock on the {0} slot.", slot, itemId);
+                else
+                    log.Debug("[Proteus] SetItem({0},{1}) -> {2}", slot, itemId, ec);
                 return false;
             }
             return true;
@@ -426,6 +437,10 @@ public class GlamourerBridge : IDisposable
         // shell's host with them.
         if (changeType is StateChangeType.Equip or StateChangeType.BonusItem)
         {
+            // Our own ReapplyState raises an Equip per slot, and each one schedules another composite
+            // that reapplies again. Cost: a foreign equip inside the window is dropped until the next trigger.
+            if (WithinOwnReapplyEcho()) return;
+
             LocalPlayerEquipmentChanged?.Invoke();
             return;
         }

--- a/Proteus/Services/CompositorService.cs
+++ b/Proteus/Services/CompositorService.cs
@@ -2673,11 +2673,16 @@ public class CompositorService : IDisposable
                 // a multi-second composite, by which point the window had always lapsed.
                 ScheduleCarrierRetry((int)(GlassesInjectCooldownMs - sinceInject));
 
-            if (MetSnapshotKnown && !AnyMetWorn()
-                && sinceInject > GlassesInjectCooldownMs
-                && SetGlassesOnFramework(g.ItemId))
+            if (MetSnapshotKnown && !AnyMetWorn() && sinceInject > GlassesInjectCooldownMs)
             {
+                // Charge the cooldown on the ATTEMPT, not the success. A slot locked by another plugin
+                // refuses every equip, and stamping only on success left the window permanently open:
+                // the redraw hook and ScheduleCarrierRetry then re-tried on every single redraw.
+                var equipped = SetGlassesOnFramework(g.ItemId);
                 _lastGlassesInjectTick = Environment.TickCount64;
+                if (!equipped)
+                    return;
+
                 _injectedGlasses = true;
                 if (alreadyHosted)
                 {
@@ -2832,9 +2837,12 @@ public class CompositorService : IDisposable
             return;
         }
 
-        if (SetAccessoryOnFramework(r.ItemId, ringSlot))
+        // Charge the cooldown on the ATTEMPT, not the success — see the glasses. A slot another plugin has
+        // locked refuses every equip, and stamping only on success left the window permanently open.
+        var equipped = SetAccessoryOnFramework(r.ItemId, ringSlot);
+        _lastRingInjectTick = Environment.TickCount64;
+        if (equipped)
         {
-            _lastRingInjectTick = Environment.TickCount64;
             MarkCarrierInjected(ringSlot);
             // No follow-up recomposite: the shell is ALREADY published at the path this piece loads, so the
             // equip's own redraw lands on the finished shell (the glasses path needs one only when it


### PR DESCRIPTION
Handle cooldowns on equip attempt rather than success; improve logging for Glamourer lock conflicts.

This fixes an issue I'm getting when one plugin locks the glamour slot and because that slot is locked, my character's weapon starts flashing in and out of existence.