### PR TITLE
Make hat compatibility on by default, and report each fit in chat

### DIFF
--- a/Proteus/Configuration.cs
+++ b/Proteus/Configuration.cs
@@ -56,7 +56,7 @@ public class Configuration : IPluginConfiguration
     /// brand-new config is stamped current and so never runs a migration written for settings it was
     /// never saved with.
     /// </summary>
-    public const int CurrentVersion = 4;
+    public const int CurrentVersion = 5;
 
     public int Version { get; set; } = CurrentVersion;
 
@@ -240,16 +240,27 @@ public class Configuration : IPluginConfiguration
     /// <c>shp_hib</c> shape key pressing what remains against the skull on a fade that releases below.
     /// Both are native to the game, so a patched hairstyle keeps working with Proteus turned off.
     /// <para/>
-    /// OFF BY DEFAULT, and deliberately so — no initializer here, which is the default this relies on. The
-    /// edit is written INTO the hair mod's own files rather than into a Proteus redirect, and that is the
-    /// point of it: it survives Proteus being disabled and travels with an export. It also means enabling
-    /// this lets Proteus modify somebody else's mod folder unattended, which is not something to assume
-    /// consent for. Originals are copied to <c>Proteus/hatcompat-backup/</c> before the first edit and the
-    /// change is undoable per hairstyle.
+    /// ON BY DEFAULT. It was off at first because the edit is written INTO the hair mod's own files rather
+    /// than into a Proteus redirect, which means the automatic path modifies somebody else's mod folder
+    /// unattended — and that is not normally something to assume consent for. What makes it assumable here
+    /// is that the edit is reversible and says so: the author's files are copied to
+    /// <c>Proteus/hatcompat-backup/</c> before the first write, the change is undoable per hairstyle, and
+    /// each hairstyle it fits is reported in chat with both ways out (see
+    /// <c>HatCompatWatcher.Announce</c>). Left off, the overwhelmingly common outcome was a hat going
+    /// straight through modded hair and nobody knowing there was a setting for it.
+    /// <para/>
+    /// Writing into the mod is still the point of the design rather than an awkwardness of it: a patched
+    /// hairstyle keeps working with Proteus disabled, and travels with an export.
     /// <para/>
     /// Hairstyles whose author already shipped a hat shape are left alone entirely.
     /// </summary>
-    public bool AutoHatCompat { get; set; }
+    public bool AutoHatCompat { get; set; } = true;
+
+    // There is deliberately no "the hat-compat notice has been shown" flag here. The chat line fires per
+    // HAIRSTYLE FITTED, which the patch record on disk already tracks exactly — see
+    // HatCompatWatcher.Announce. A once-ever flag was tried and is the wrong shape: it buys quiet by
+    // letting the tenth mod folder be edited as silently as if nothing had been said, and every edit after
+    // the first is the one the user has no way of learning about otherwise.
 
     // HatCompatHidePonytails was removed. It tagged whole ponytails so the game dropped them under a hat,
     // and it rested on telling a tail from a parting by geometry alone — a judgement wrong often enough that
@@ -541,6 +552,19 @@ public class Configuration : IPluginConfiguration
         // Unconditional, not guarded on the old value being non-default: BOTH states are meaningful here,
         // and false -> true is exactly what a config that never touched the setting should get anyway.
         if (Version < 4) AutoRedraw = !DisableAutoRedraw;
+
+        // v4 -> v5: hat compatibility is on by default now, and existing configs have to be moved rather
+        // than left on the property default, which only a brand-new config ever sees. Everyone who had run
+        // the plugin before this would otherwise keep a hat going through their hair with no sign that
+        // anything had changed.
+        //
+        // Unconditional, because the stored false carries NO information: the setting shipped off, so
+        // "never touched it" and "tried it and turned it off" are the same byte on disk and there is
+        // nothing to tell them apart with. Someone in the second group is turned back on once, and the
+        // chat line that fires on the next fit tells them where to switch it off again — which is a worse
+        // outcome for them than for the many people in the first group who would never have found the
+        // setting at all. Anyone who had it ON is unaffected.
+        if (Version < 5) AutoHatCompat = true;
 
         Version = CurrentVersion;
     }

--- a/Proteus/Localization/de.json
+++ b/Proteus/Localization/de.json
@@ -123,6 +123,10 @@
     "message": "[Proteus] „{0}“ setzt Leuchten auf einer Hautebene. Haut kann nicht mehr leuchten, daher wird diese Option jetzt als Stoffebene dargestellt — sie braucht ein freies Accessoire und ihre Oberfläche sieht etwas anders aus.",
     "description": ""
   },
+  "Chat.HatCompat": {
+    "message": "[Proteus] Proteus hat diese Frisur hutkompatibel gemacht. Du kannst das unter /proteus > Einstellungen > Hüte rückgängig machen oder die Funktion dort abschalten.",
+    "description": "Chat line shown once ever, the first time Proteus makes a hairstyle fit under hats by itself. Do NOT translate \"Proteus\" or the command \"/proteus\". \"Settings\" and \"Hats\" name a tab and a section in Proteus' own window - use the same words you used for \"Tab.Settings\" and \"Settings.Section.HatCompat\"."
+  },
   "Chat.MirrorRepo": {
     "message": "[Proteus] Du hast über die alte Plugin-Repository-URL installiert. Wenn du sie unter /xlplugins > Experimental auf https://dl.solona.info/repo.json umstellst, werden Updates schneller und GitHub wird entlastet. Deine Installation funktioniert so oder so weiter. Dieser Hinweis erscheint noch einige Male und hört dann auf.",
     "description": "Chat line shown at most three times to users installed from the old plugin repository URL. Do NOT translate the URL, \"/xlplugins\", or \"Proteus\". \"Experimental\" is the name of a tab in Dalamud's plugin installer - use whatever that tab is called in your language."

--- a/Proteus/Localization/en.json
+++ b/Proteus/Localization/en.json
@@ -123,6 +123,10 @@
     "message": "[Proteus] \"{0}\" sets Glow on a skin layer. Skin can no longer glow, so that option now renders as a cloth layer — it needs a free accessory to sit on, and its surface will look slightly different.",
     "description": "Appears in an in-game chat notice from Proteus. Takes arguments - keep every {0}, {1} ... exactly once; you may reorder them."
   },
+  "Chat.HatCompat": {
+    "message": "[Proteus] Proteus has made this hairstyle fit under hats. You can undo that, or turn the feature off, under /proteus > Settings > Hats.",
+    "description": "Chat line shown once ever, the first time Proteus makes a hairstyle fit under hats by itself. Do NOT translate \"Proteus\" or the command \"/proteus\". \"Settings\" and \"Hats\" name a tab and a section in Proteus' own window - use the same words you used for \"Tab.Settings\" and \"Settings.Section.HatCompat\"."
+  },
   "Chat.MirrorRepo": {
     "message": "[Proteus] You installed from the old plugin repo URL. Switching it to https://dl.solona.info/repo.json under /xlplugins > Experimental makes updates faster and takes load off GitHub. Your install keeps working either way. This reminder shows a few times, then stops.",
     "description": "Chat line shown at most three times to users installed from the old plugin repository URL. Do NOT translate the URL, \"/xlplugins\", or \"Proteus\". \"Experimental\" is the name of a tab in Dalamud's plugin installer - use whatever that tab is called in your language."

--- a/Proteus/Localization/es.json
+++ b/Proteus/Localization/es.json
@@ -123,6 +123,10 @@
     "message": "[Proteus] «{0}» aplica brillo en una capa de piel. La piel ya no puede brillar, así que esa opción se representa ahora como capa de tela: necesita un accesorio libre y su superficie se verá algo distinta.",
     "description": ""
   },
+  "Chat.HatCompat": {
+    "message": "[Proteus] Proteus ha hecho que este peinado quepa bajo los sombreros. Puedes deshacerlo, o desactivar la función, en /proteus > Ajustes > Sombreros.",
+    "description": "Chat line shown once ever, the first time Proteus makes a hairstyle fit under hats by itself. Do NOT translate \"Proteus\" or the command \"/proteus\". \"Settings\" and \"Hats\" name a tab and a section in Proteus' own window - use the same words you used for \"Tab.Settings\" and \"Settings.Section.HatCompat\"."
+  },
   "Chat.MirrorRepo": {
     "message": "[Proteus] Instalaste desde la URL antigua del repositorio de plugins. Cambiarla a https://dl.solona.info/repo.json en /xlplugins > Experimental hace que las actualizaciones sean más rápidas y reduce la carga en GitHub. Tu instalación seguirá funcionando de cualquier modo. Este aviso se muestra unas pocas veces y luego deja de aparecer.",
     "description": "Chat line shown at most three times to users installed from the old plugin repository URL. Do NOT translate the URL, \"/xlplugins\", or \"Proteus\". \"Experimental\" is the name of a tab in Dalamud's plugin installer - use whatever that tab is called in your language."

--- a/Proteus/Localization/fr.json
+++ b/Proteus/Localization/fr.json
@@ -123,6 +123,10 @@
     "message": "[Proteus] « {0} » applique une lueur sur un calque de peau. La peau ne peut plus briller, donc cette option est désormais rendue comme un calque de tissu — elle a besoin d'un accessoire libre, et sa surface aura un aspect légèrement différent.",
     "description": ""
   },
+  "Chat.HatCompat": {
+    "message": "[Proteus] Proteus a rendu cette coiffure compatible avec les chapeaux. Vous pouvez annuler cela, ou désactiver la fonction, dans /proteus > Paramètres > Chapeaux.",
+    "description": "Chat line shown once ever, the first time Proteus makes a hairstyle fit under hats by itself. Do NOT translate \"Proteus\" or the command \"/proteus\". \"Settings\" and \"Hats\" name a tab and a section in Proteus' own window - use the same words you used for \"Tab.Settings\" and \"Settings.Section.HatCompat\"."
+  },
   "Chat.MirrorRepo": {
     "message": "[Proteus] Vous avez installé depuis l'ancienne URL du dépôt de plugins. La remplacer par https://dl.solona.info/repo.json dans /xlplugins > Experimental accélère les mises à jour et allège la charge sur GitHub. Votre installation continue de fonctionner dans tous les cas. Ce rappel s'affiche quelques fois, puis disparaît.",
     "description": "Chat line shown at most three times to users installed from the old plugin repository URL. Do NOT translate the URL, \"/xlplugins\", or \"Proteus\". \"Experimental\" is the name of a tab in Dalamud's plugin installer - use whatever that tab is called in your language."

--- a/Proteus/Localization/ja.json
+++ b/Proteus/Localization/ja.json
@@ -123,6 +123,10 @@
     "message": "[Proteus]「{0}」は肌レイヤーにグローを設定しています。肌はもう発光できないため、このオプションは布レイヤーとして描画されます。空いているアクセサリが必要になり、表面の見え方も少し変わります。",
     "description": ""
   },
+  "Chat.HatCompat": {
+    "message": "[Proteus] Proteus がこの髪型を帽子に対応させました。元に戻す、またはこの機能をオフにするには /proteus > 設定 > 帽子 を開いてください。",
+    "description": "Chat line shown once ever, the first time Proteus makes a hairstyle fit under hats by itself. Do NOT translate \"Proteus\" or the command \"/proteus\". \"Settings\" and \"Hats\" name a tab and a section in Proteus' own window - use the same words you used for \"Tab.Settings\" and \"Settings.Section.HatCompat\"."
+  },
   "Chat.MirrorRepo": {
     "message": "[Proteus] 古いプラグインリポジトリのURLからインストールされています。/xlplugins > Experimental で https://dl.solona.info/repo.json に変更すると、更新が速くなり、GitHubの負荷も減ります。変更しなくても引き続き動作します。この通知は数回表示された後、表示されなくなります。",
     "description": "Chat line shown at most three times to users installed from the old plugin repository URL. Do NOT translate the URL, \"/xlplugins\", or \"Proteus\". \"Experimental\" is the name of a tab in Dalamud's plugin installer - use whatever that tab is called in your language."

--- a/Proteus/Localization/ko.json
+++ b/Proteus/Localization/ko.json
@@ -123,6 +123,10 @@
     "message": "[Proteus] \"{0}\"이(가) 피부 레이어에 발광을 설정했습니다. 피부는 더 이상 발광할 수 없으므로 이 옵션은 이제 천 레이어로 렌더링됩니다. 비어 있는 장신구 칸이 필요하며, 표면도 조금 다르게 보입니다.",
     "description": ""
   },
+  "Chat.HatCompat": {
+    "message": "[Proteus] Proteus가 이 헤어스타일을 모자에 맞게 수정했습니다. /proteus > 설정 > 모자 에서 되돌리거나 이 기능을 끌 수 있습니다.",
+    "description": "Chat line shown once ever, the first time Proteus makes a hairstyle fit under hats by itself. Do NOT translate \"Proteus\" or the command \"/proteus\". \"Settings\" and \"Hats\" name a tab and a section in Proteus' own window - use the same words you used for \"Tab.Settings\" and \"Settings.Section.HatCompat\"."
+  },
   "Chat.MirrorRepo": {
     "message": "[Proteus] 이전 플러그인 저장소 URL로 설치되었습니다. /xlplugins > Experimental에서 https://dl.solona.info/repo.json 으로 변경하면 업데이트가 빨라지고 GitHub 부하도 줄어듭니다. 변경하지 않아도 설치는 계속 작동합니다. 이 알림은 몇 번 표시된 후 사라집니다.",
     "description": "Chat line shown at most three times to users installed from the old plugin repository URL. Do NOT translate the URL, \"/xlplugins\", or \"Proteus\". \"Experimental\" is the name of a tab in Dalamud's plugin installer - use whatever that tab is called in your language."

--- a/Proteus/Localization/ru.json
+++ b/Proteus/Localization/ru.json
@@ -123,6 +123,10 @@
     "message": "[Proteus] «{0}» задаёт свечение на слое кожи. Кожа больше не может светиться, поэтому этот параметр теперь отрисовывается как тканевый слой — ему нужен свободный аксессуар, и поверхность будет выглядеть немного иначе.",
     "description": ""
   },
+  "Chat.HatCompat": {
+    "message": "[Proteus] Proteus подогнал эту причёску под шляпы. Отменить это или отключить функцию можно в /proteus > Настройки > Шляпы.",
+    "description": "Chat line shown once ever, the first time Proteus makes a hairstyle fit under hats by itself. Do NOT translate \"Proteus\" or the command \"/proteus\". \"Settings\" and \"Hats\" name a tab and a section in Proteus' own window - use the same words you used for \"Tab.Settings\" and \"Settings.Section.HatCompat\"."
+  },
   "Chat.MirrorRepo": {
     "message": "[Proteus] Вы установили плагин по старому адресу репозитория. Если поменять его на https://dl.solona.info/repo.json в /xlplugins > Experimental, обновления станут быстрее, а нагрузка на GitHub снизится. Установка продолжит работать в любом случае. Это напоминание появится ещё несколько раз, а затем исчезнет.",
     "description": "Chat line shown at most three times to users installed from the old plugin repository URL. Do NOT translate the URL, \"/xlplugins\", or \"Proteus\". \"Experimental\" is the name of a tab in Dalamud's plugin installer - use whatever that tab is called in your language."

--- a/Proteus/Localization/zh.json
+++ b/Proteus/Localization/zh.json
@@ -123,6 +123,10 @@
     "message": "[Proteus]“{0}”在皮肤层上设置了发光。皮肤已无法发光，因此该选项现在按布料层渲染——它需要一个空闲的饰品栏位，表面效果也会略有不同。",
     "description": ""
   },
+  "Chat.HatCompat": {
+    "message": "[Proteus] Proteus 已让这个发型能戴在帽子下面。你可以在 /proteus > 设置 > 帽子 中撤销此更改，或关闭该功能。",
+    "description": "Chat line shown once ever, the first time Proteus makes a hairstyle fit under hats by itself. Do NOT translate \"Proteus\" or the command \"/proteus\". \"Settings\" and \"Hats\" name a tab and a section in Proteus' own window - use the same words you used for \"Tab.Settings\" and \"Settings.Section.HatCompat\"."
+  },
   "Chat.MirrorRepo": {
     "message": "[Proteus] 你是通过旧的插件仓库地址安装的。在 /xlplugins > Experimental 中改为 https://dl.solona.info/repo.json 可以让更新更快，并减轻 GitHub 的负担。无论是否更改，你的安装都能继续使用。此提醒会显示几次后不再出现。",
     "description": "Chat line shown at most three times to users installed from the old plugin repository URL. Do NOT translate the URL, \"/xlplugins\", or \"Proteus\". \"Experimental\" is the name of a tab in Dalamud's plugin installer - use whatever that tab is called in your language."

--- a/Proteus/Plugin.cs
+++ b/Proteus/Plugin.cs
@@ -26,7 +26,7 @@ public sealed class Plugin : IDalamudPlugin
     /// <summary>Bumped when there's something worth calling out. NOT a reliable "did my rebuild load?"
     /// signal on its own — it is hand-maintained, and it sat at 254 across dozens of builds because
     /// bumping it is easy to forget. <see cref="BuildStamp"/> is the one that can't go stale.</summary>
-    public const int BuildNumber = 710;
+    public const int BuildNumber = 711;
 
     /// <summary>
     /// When this assembly was compiled, as MM-dd HH:mm:ss. Baked in by the csproj (an AssemblyMetadata

--- a/Proteus/Services/HatCompatWatcher.cs
+++ b/Proteus/Services/HatCompatWatcher.cs
@@ -306,7 +306,7 @@ public sealed class HatCompatWatcher : IDisposable
         // PluginEnabled as well as the setting: the events this also listens to reach it whether or not the
         // poll is running, so gating the poll alone would still let a Penumbra change trigger a write.
         if (mayApply && config.PluginEnabled && config.AutoHatCompat && !proposal.AlreadyCompatible)
-            Write(target, proposal);
+            Write(target, proposal, automatic: true);
     }
 
     /// <summary>Which hairstyle this is, independent of anything an edit to it would change.</summary>
@@ -324,7 +324,10 @@ public sealed class HatCompatWatcher : IDisposable
         var proposal = view.Proposal;
         Task.Run(() =>
         {
-            try { Write(target, proposal); }
+            // automatic: false — the user pressed the button, so the "Proteus has done this to your hair"
+            // notice would be telling them something they just did. The panel they pressed it in already
+            // says where the backup goes and that it can be undone.
+            try { Write(target, proposal, automatic: false); }
             catch (Exception ex)
             {
                 log.Error(ex, "hat compat: applying to {0} failed", target.Rel);
@@ -338,7 +341,9 @@ public sealed class HatCompatWatcher : IDisposable
         });
     }
 
-    private void Write(HatCompatService.Target target, HatCompatService.Proposal proposal)
+    /// <param name="automatic">The fit was Proteus's own idea rather than a button press, so it announces
+    /// itself in chat. See <see cref="Announce"/>.</param>
+    private void Write(HatCompatService.Target target, HatCompatService.Proposal proposal, bool automatic)
     {
         // WHERE IT THINKS THE HEAD IS, every time. The hat line is an offset from that centre and every
         // other decision is measured from it, so a cut landing somewhere absurd is either a bad centre or
@@ -371,6 +376,10 @@ public sealed class HatCompatWatcher : IDisposable
             log.Warning("hat compat: {0} — {1} vertices could not be given a shape value at all; this hair is "
                       + "welded into meshes too large for the format to address", target.Rel,
                         outcome.Unaddressable);
+
+        // HERE, not before the apply: the notice reports something that happened, and a write that then
+        // failed would have announced an edit the mod folder never received.
+        if (automatic) Announce();
 
         // The same hairstyle again, from every other option that supplies it. Each gets its own solve —
         // a long version and a short one are different geometry and the tails are not in the same places.
@@ -411,6 +420,49 @@ public sealed class HatCompatWatcher : IDisposable
             log.Information("hat compat: asked Penumbra to reload {0} — {1}", modDir, ec);
         }
         compositor.RedrawForChangedModel();
+    }
+
+    /// <summary>
+    /// Say in chat that Proteus has fitted the hairstyle just put on — and where to undo it or switch the
+    /// feature off.
+    /// <para/>
+    /// The price of having the feature on by default. The fit is a silent edit to someone else's mod
+    /// folder, which the user did not ask for; saying so at the moment it happens is what separates that
+    /// from Proteus rummaging about behind their back. It also puts the two ways out in front of them,
+    /// which is the part a log line could never do.
+    /// <para/>
+    /// ONCE PER HAIRSTYLE, and that needs no bookkeeping of its own: a fit only reaches here when the
+    /// hairstyle was not already patched, and <see cref="HatCompatService.Apply"/> records the file before
+    /// reporting success — so wearing the same hairstyle again is silent, and only a refit by a newer
+    /// solver speaks again. Wearing a SECOND hairstyle is a second edit to a second file, and a line each
+    /// is the honest account of that. A once-ever flag was the wrong shape for precisely that reason: it
+    /// bought quiet by letting the tenth mod folder be edited as silently as if nothing had been said.
+    /// </summary>
+    private void Announce()
+    {
+        // Fire and forget onto the framework thread: this runs on a worker that has just spent a while
+        // reading and rewriting a model, and Dalamud's chat does not belong there.
+        //
+        // The catch goes INSIDE the lambda, not around the dispatch. RunOnFrameworkThread captures
+        // whatever the action throws into the task it returns, and that task is discarded here — so a
+        // catch out here would see only a failure to SCHEDULE, and a print that threw would disappear
+        // without a word in the log.
+        _ = Plugin.Framework.RunOnFrameworkThread(() =>
+        {
+            try
+            {
+                // The fit can finish just as the plugin is being torn down, and this is queued for a frame
+                // that may never come — by which time what it reaches for is gone.
+                if (disposed) return;
+                Plugin.ChatGui.Print(new Dalamud.Game.Text.SeStringHandling.SeStringBuilder()
+                    .AddUiForeground(
+                        CheapLoc.Loc.Localize("Chat.HatCompat",
+                            "[Proteus] Proteus has made this hairstyle fit under hats. You can undo that, or "
+                          + "turn the feature off, under /proteus > Settings > Hats."), 45)
+                    .Build());
+            }
+            catch (Exception ex) { log.Warning(ex, "hat compat: could not announce the fit in chat"); }
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
It was off because the fit is written into the hair mod's own files, and editing somebody else's mod folder unattended is not something to assume consent for. The cost of that caution was that a hat went straight through modded hair for almost everyone, and the setting that fixes it was never found.

On by default now, with a v4 -> v5 migration so existing configs move too rather than sitting on a property default that only new installs ever see. The step is unconditional, because a stored false carries no information: the setting shipped off, so "never touched it" and "tried it and turned it off" are the same byte on disk.

What makes that defensible is the chat line. Each hairstyle Proteus fits says so, with both ways out - undo it, or switch the feature off. Once per HAIRSTYLE, and that needs no bookkeeping of its own: Write is only reached for a hairstyle that is not already patched, and Apply records the file before it reports success, so wearing the same hair again is silent. A once-ever flag was tried and removed - it bought quiet by letting the tenth mod folder be edited as silently as if nothing had been said.

A fit the user asked for with the button stays silent; they are looking at the panel that already explains the backup and the undo.